### PR TITLE
[WIP] Add support for Redis Clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ This middleware caches incoming `GET` requests on the strapi API, based on query
 The cache is automatically busted everytime a `PUT`, `POST`, or `DELETE` request comes in.
 
 Supported storage engines
-* Memory _(default)_
-* Redis
+
+-   Memory _(default)_
+-   Redis
 
 Important: Caching must be explicitely enabled **per model**
 
@@ -60,7 +61,6 @@ $ strapi develop
 The middleware will only cache models which have been explicitely enabled.
 Add a list of models to enable to the module's configuration object.
 
-
 e.g
 
 ```javascript
@@ -86,15 +86,16 @@ $ strapi develop
 
 The module's configuration object supports the following properties
 
-| Property                        | Default   | Description                                                   |
-| ------------------------------- | --------- | --------------------------------------------------------------|
-| type                            | mem       | The type of storage engine to use (`mem` or `redis`)          |
-| max                             | 500       | Max number of entries in the cache                            |
-| maxAge                          | 3600000   | Time in milliseconds after which a cache entry is invalidated |
-| redisConfig _(redis only)_      | {}        | The redis config object passed on to [ioredis](https://www.npmjs.com/package/ioredis) |
+| Property                     | Default | Description                                                                                 |
+| ---------------------------- | ------- | ------------------------------------------------------------------------------------------- |
+| type                         | mem     | The type of storage engine to use (`mem` or `redis`)                                        |
+| max                          | 500     | Max number of entries in the cache                                                          |
+| maxAge                       | 3600000 | Time in milliseconds after which a cache entry is invalidated                               |
+| redisConfig _(redis only)_   | {}      | The redis config object/array passed on to [ioredis](https://www.npmjs.com/package/ioredis) |
+| cluster _(redis only)_       | false   | Boolean to set [ioredis](https://www.npmjs.com/package/ioredis) into cluster mode           |
+| clusterConfig _(redis only)_ | {}      | The redis cluster settings object to define additional cluster settings                     |
 
-
-### Example
+### Example - Redis Sentinel
 
 ```javascript
 // config/development/middlewares.json
@@ -122,6 +123,46 @@ Running the CMS will output the following
 $ strapi develop
 [2020-04-14T11:31:05.751Z] info [Cache] Mounting LRU cache middleware
 [2020-04-14T11:31:05.752Z] info [Cache] Storage engine: redis
+[2020-04-14T11:31:05.784Z] info [Cache] Caching route /listings/:id* [maxAge=3600000]
+[2020-04-14T11:31:06.076Z] info [Cache] Redis connection established
+```
+
+### Example - Redis Cluster
+
+```javascript
+// config/development/middlewares.json
+{
+  "cache": {
+    "enabled": true,
+    "type": "redis",
+    "cluster": true
+    "maxAge": 3600000,
+    "models": ["posts"],
+    "redisConfig": [
+      {
+        "port": 6379,
+        "host": "192.168.10.41"
+      },
+      {
+        "port": 6379,
+        "host": "192.168.10.42"
+      },
+      {
+        "port": 6379,
+        "host": "192.168.10.43"
+      }
+    ]
+  }
+}
+```
+
+Running the CMS will output the following
+
+```
+$ strapi develop
+[2020-04-14T11:31:05.751Z] info [Cache] Mounting LRU cache middleware
+[2020-04-14T11:31:05.752Z] info [Cache] Storage engine: redis
+[2020-04-14T11:31:05.753Z] info [Cache] Cluster: true
 [2020-04-14T11:31:05.784Z] info [Cache] Caching route /listings/:id* [maxAge=3600000]
 [2020-04-14T11:31:06.076Z] info [Cache] Redis connection established
 ```

--- a/lib/cache/stores/redis.js
+++ b/lib/cache/stores/redis.js
@@ -1,16 +1,18 @@
-const _         = require('lodash');
-const Redis     = require('ioredis');
-const lru       = require('redis-lru');
+const _ = require('lodash');
+const Redis = require('ioredis');
+const lru = require('redis-lru');
 const { defer } = require('../../async');
 
 module.exports = (strapi, opts = {}) => {
   const redisOpts = _.get(opts, ['redisConfig'], {});
+  const isCluster = _.get(opts, ['cluster'], false);
+  const clusterOpts = _.get(opts, ['clusterConfig'], {});
   const prefix = (key) => `strapi-middleware-cache:${key}`;
   const unprefix = (key) => key.replace(/^strapi-middleware-cache:/, '')
 
-  const deferred  = defer();
-  const client    = new Redis(redisOpts);
-  const cache     = lru(client, opts.max);
+  const deferred = defer();
+  const client = (isCluster === true) ? new Redis.Cluster(redisOpts, clusterOpts) : new Redis(redisOpts);
+  const cache = lru(client, opts.max);
 
   client.once("ready", () => {
     strapi.log.info('[Cache] Redis connection established')
@@ -22,8 +24,8 @@ module.exports = (strapi, opts = {}) => {
     strapi.log.error(e);
     return deferred.reject(e)
   });
-  
-  return  {
+
+  return {
     get(key) {
       return cache.get(prefix(key));
     },

--- a/lib/index.js
+++ b/lib/index.js
@@ -48,6 +48,10 @@ const Cache = (strapi) => {
       info('Mounting LRU cache middleware');
       info(`Storage engine: ${type}`);
 
+      if (options.cluster === true) {
+        info(`Cluster: true`);
+      }
+
       const router  = new Router();
       const cache   = createCache(strapi, type, options);
 


### PR DESCRIPTION
This PR is a work in progress is currently having some problems with `redis-lru` it appears they are trying to make multiple pipeline actions against multiple keys.

Bug in Strapi console:

```
Error: All keys in the pipeline should belong to the same slot
      at Pipeline.exec (/home/dmehaffy/Development/testCache/node_modules/ioredis/built/pipeline.js:216:29)
      at Pipeline.pipeline.exec (/home/dmehaffy/Development/testCache/node_modules/ioredis/built/transaction.js:38:34)
      at /home/dmehaffy/Development/testCache/node_modules/redis-lru/index.js:10:8
      at new Promise (<anonymous>)
      at asPromise (/home/dmehaffy/Development/testCache/node_modules/redis-lru/index.js:4:10)
      at Object.get (/home/dmehaffy/Development/testCache/node_modules/redis-lru/index.js:92:12)
      at Object.get (/home/dmehaffy/Development/testCache/node_modules/strapi-middleware-cache/lib/cache/stores/redis.js:31:20)
      at get (/home/dmehaffy/Development/testCache/node_modules/strapi-middleware-cache/lib/cache/index.js:23:38)
      at Object.get (/home/dmehaffy/Development/testCache/node_modules/strapi-middleware-cache/lib/cache/index.js:42:18)
      at processTicksAndRejections (internal/process/task_queues.js:97:5)
      at async /home/dmehaffy/Development/testCache/node_modules/strapi-middleware-cache/lib/index.js:91:30
      at async /home/dmehaffy/Development/testCache/node_modules/strapi/lib/middlewares/responses/index.js:9:9
      at async cors (/home/dmehaffy/Development/testCache/node_modules/@koa/cors/index.js:56:32)
      at async /home/dmehaffy/Development/testCache/node_modules/strapi/lib/middlewares/logger/index.js:39:11
      at async /home/dmehaffy/Development/testCache/node_modules/strapi/lib/middlewares/responseTime/index.js:17:9
      at async /home/dmehaffy/Development/testCache/node_modules/strapi/lib/services/metrics/middleware.js:29:5
```