### PR TITLE
Allow user to disable logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Starting the CMS should now log the following
 
 ```
 $ strapi develop
-[2020-04-14T11:12:41.648Z] info [Cache] Mounting LRU cache middleware
-[2020-04-14T11:12:41.648Z] info [Cache] Storage engine: mem
+[2020-04-14T11:12:41.648Z] debug [Cache] Mounting LRU cache middleware
+[2020-04-14T11:12:41.648Z] debug [Cache] Storage engine: mem
 ```
 
 ## Configure models
@@ -77,9 +77,9 @@ Starting the CMS should now log the following
 
 ```
 $ strapi develop
-[2020-04-14T11:12:41.648Z] info [Cache] Mounting LRU cache middleware
-[2020-04-14T11:12:41.648Z] info [Cache] Storage engine: mem
-[2020-04-14T11:12:41.653Z] info [Cache] Caching route /posts/:id* [maxAge=3600000]
+[2020-04-14T11:12:41.648Z] debug [Cache] Mounting LRU cache middleware
+[2020-04-14T11:12:41.648Z] debug [Cache] Storage engine: mem
+[2020-04-14T11:12:41.653Z] debug [Cache] Caching route /posts/:id* [maxAge=3600000]
 ```
 
 ## Configure the storage engine
@@ -91,6 +91,7 @@ The module's configuration object supports the following properties
 | type                            | mem       | The type of storage engine to use (`mem` or `redis`)          |
 | max                             | 500       | Max number of entries in the cache                            |
 | maxAge                          | 3600000   | Time in milliseconds after which a cache entry is invalidated |
+| logs                            | true      | Setting it to false will disable any console output           |
 | redisConfig _(redis only)_      | {}        | The redis config object passed on to [ioredis](https://www.npmjs.com/package/ioredis) |
 
 
@@ -120,10 +121,10 @@ Running the CMS will output the following
 
 ```
 $ strapi develop
-[2020-04-14T11:31:05.751Z] info [Cache] Mounting LRU cache middleware
-[2020-04-14T11:31:05.752Z] info [Cache] Storage engine: redis
-[2020-04-14T11:31:05.784Z] info [Cache] Caching route /listings/:id* [maxAge=3600000]
-[2020-04-14T11:31:06.076Z] info [Cache] Redis connection established
+[2020-04-14T11:31:05.751Z] debug [Cache] Mounting LRU cache middleware
+[2020-04-14T11:31:05.752Z] debug [Cache] Storage engine: redis
+[2020-04-14T11:31:05.784Z] debug [Cache] Caching route /listings/:id* [maxAge=3600000]
+[2020-04-14T11:31:06.076Z] debug [Cache] Redis connection established
 ```
 
 ## Per-Model Configuration
@@ -152,8 +153,8 @@ Running the CMS should now show the following
 
 ```
 $ strapi develop
-[2020-04-14T11:37:16.510Z] info [Cache] Mounting LRU cache middleware
-[2020-04-14T11:37:16.511Z] info [Cache] Storage engine: redis
-[2020-04-14T11:37:16.600Z] info [Cache] Caching route /listings/:id* [maxAge=1000000]
-[2020-04-14T11:37:16.946Z] info [Cache] Redis connection established
+[2020-04-14T11:37:16.510Z] debug [Cache] Mounting LRU cache middleware
+[2020-04-14T11:37:16.511Z] debug [Cache] Storage engine: redis
+[2020-04-14T11:37:16.600Z] debug [Cache] Caching route /listings/:id* [maxAge=1000000]
+[2020-04-14T11:37:16.946Z] debug [Cache] Redis connection established
 ```

--- a/lib/cache/stores/redis.js
+++ b/lib/cache/stores/redis.js
@@ -4,7 +4,8 @@ const lru       = require('redis-lru');
 const { defer } = require('../../async');
 
 module.exports = (strapi, opts = {}) => {
-  const redisOpts = _.get(opts, ['redisConfig'], {});
+  const redisOpts = _.get(opts, 'redisConfig', {});
+  const allowLogs = _.get(opts, 'logs', true);
   const prefix = (key) => `strapi-middleware-cache:${key}`;
   const unprefix = (key) => key.replace(/^strapi-middleware-cache:/, '')
 
@@ -13,7 +14,9 @@ module.exports = (strapi, opts = {}) => {
   const cache     = lru(client, opts.max);
 
   client.once("ready", () => {
-    strapi.log.info('[Cache] Redis connection established')
+    if (allowLogs) {
+      strapi.log.debug('[Cache] Redis connection established')
+    }
     deferred.resolve(true)
   });
 

--- a/lib/defaults.json
+++ b/lib/defaults.json
@@ -3,6 +3,7 @@
     "enabled": true,
     "type": "mem",
     "max": 500,
-    "maxAge": 3600000
+    "maxAge": 3600000,
+    "logs": true
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,10 +31,11 @@ const generateCacheKey = (model, ctx) => {
  * @param {Strapi} strapi
  */
 const Cache = (strapi) => {
-  const options = _.get(strapi, `config.middleware.settings.${PLUGIN_NAME}`, {});
-  const type    = _.get(options, 'type', 'mem');
+  const options   = _.get(strapi, `config.middleware.settings.${PLUGIN_NAME}`, {});
+  const type      = _.get(options, 'type', 'mem');
+  const allowLogs = _.get(options, 'logs', true);
 
-  const info = (msg) => strapi.log.info(`[Cache] ${msg}`)
+  const info = (msg) => allowLogs && strapi.log.debug(`[Cache] ${msg}`)
 
   const toCache  = _.chain(options)
     .get('models', [])

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-middleware-cache",
-  "version": "1.0.1",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-middleware-cache",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Cache strapi requests",
   "main": "./lib",
   "scripts": {


### PR DESCRIPTION
## Change

- Downgrade the middleware's log usage to `debug` (previously `info`)
- Add the `logs` option as an alternative to disable logs

closes #5 