### PR TITLE
Changes done on the admin panel busts the cache

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 const createCache   = require('./cache');
 const Router        = require('koa-router');
 const _             = require('lodash');
+const pluralize     = require('pluralize');
 
 const PLUGIN_NAME = 'cache';
 
@@ -54,13 +55,15 @@ const Cache = (strapi) => {
 
       this.cache = cache;
 
+      // --- Standard REST endpoints
+
       /**
        * Creates a Koa middleware that busts the cache of a given model
        *
        * @param {string} model
        */
       const bust = (model) => async (ctx, next) => {
-        const pattern     = new RegExp(`^/${model}`);
+        const pattern     = new RegExp(`^/${pluralize(model)}`);
         const keys        = await cache.keys();
 
         await next();
@@ -75,7 +78,7 @@ const Cache = (strapi) => {
 
       _.each(toCache, (cacheConf) => {
         const { model, maxAge = options.maxAge } = cacheConf;
-        const endpoint = `/${model}/:id*`;
+        const endpoint = `/${pluralize(model)}/:id*`;
 
         info(`Caching route ${endpoint} [maxAge=${maxAge}]`);
 
@@ -100,6 +103,30 @@ const Cache = (strapi) => {
           }
         });
       });
+
+      // --- Admin REST endpoints
+
+      /**
+       * Busts the cache on receiving a modification from the admin panel
+       *
+       * @param {Koa.BaseContext} ctx
+       * @param {Function} next
+       */
+      const bustAdmin = async (ctx, next) => {
+        const model = _.chain(ctx).get('params.scope').split('.').last().value();
+
+        const isCached = _.find(toCache, ['model', pluralize(model)]);
+
+        if (isCached) {
+          await bust(model)(ctx, next)
+        } else {
+          await next();
+        }
+      };
+
+      router.post('/content-manager/explorer/:scope', bustAdmin);
+      router.put('/content-manager/explorer/:scope/:id*', bustAdmin);
+      router.delete('/content-manager/explorer/:scope/:id*', bustAdmin);
 
       strapi.app.use(router.routes());
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1144,6 +1144,11 @@
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
     },
+    "pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="
+    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-middleware-cache",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Cache strapi requests",
   "main": "./lib",
   "scripts": {
@@ -27,6 +27,7 @@
     "koa-router": "^8.0.8",
     "lodash": "^4.17.15",
     "lru-cache": "^5.1.1",
+    "pluralize": "^8.0.0",
     "redis-lru": "^0.6.0"
   },
   "devDependencies": {

--- a/tests/cache.test.js
+++ b/tests/cache.test.js
@@ -90,5 +90,21 @@ describe('Caching', () => {
       expect(res3.body.uid).to.equal(res2.body.uid + 1);
       expect(requests).to.have.lengthOf(3);
     });
+
+    it(`busts the cache on an admin panel ${method.toUpperCase()} resquest`, async () => {
+      const res1 = await agent(strapi.app).get('/posts').expect(200);
+
+      expect(requests).to.have.lengthOf(1);
+
+      const res2 = await agent(strapi.app)[method]('/content-manager/explorer/application::post.post').expect(200);
+
+      expect(res2.body.uid).to.equal(res1.body.uid + 1);
+      expect(requests).to.have.lengthOf(2);
+
+      const res3 = await agent(strapi.app).get('/posts').expect(200);
+
+      expect(res3.body.uid).to.equal(res2.body.uid + 1);
+      expect(requests).to.have.lengthOf(3);
+    });
   });
 });


### PR DESCRIPTION
The middleware now listens to the admin rest endpoints (e.g `'/content-manager/explorer/application::post.post'`) and busts the cache when those are called on `PUT/POST/DELETE`

Closes #8 