### PR TITLE
Fix: admin cache bust is broken when using y/ies pluralizations

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -121,12 +121,14 @@ const Cache = (strapi) => {
       const bustAdmin = async (ctx, next) => {
         const model = _.chain(ctx).get('params.scope').split('.').last().value();
 
-        const isCached = _.find(toCache, (cfg) => {
+        const cacheCfg = _.find(toCache, (cfg) => {
           return cfg.model === (cfg.singleType ? model : pluralize(model));
         });
 
+        const isCached = !!cacheCfg;
+
         if (isCached) {
-          await bust(model)(ctx, next)
+          await bust(cacheCfg.model)(ctx, next)
         } else {
           await next();
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-middleware-cache",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Cache strapi requests",
   "main": "./lib",
   "scripts": {

--- a/tests/cache.test.js
+++ b/tests/cache.test.js
@@ -18,7 +18,7 @@ describe('Caching', () => {
             type: 'mem',
             enabled: true,
             models: [
-              'post',
+              'academy',
               {
                 model: 'homepage',
                 singleType: true
@@ -45,7 +45,7 @@ describe('Caching', () => {
 
     it('should let uncached requests go through', async () => {
       await agent(strapi.app)
-        .get('/posts')
+        .get('/academies')
         .expect('Content-Type', /json/)
         .expect(200);
 
@@ -54,13 +54,13 @@ describe('Caching', () => {
 
     it('following request should be cached', async () => {
       const res1 = await agent(strapi.app)
-        .get('/posts')
+        .get('/academies')
         .expect(200);
 
       expect(requests).to.have.lengthOf(1);
 
       const res2 = await agent(strapi.app)
-        .get('/posts')
+        .get('/academies')
         .expect(200);
 
       expect(res1.body.uid).to.equal(res2.body.uid);
@@ -84,32 +84,32 @@ describe('Caching', () => {
 
     ['post', 'put', 'delete'].forEach(method => {
       it(`busts the cache on a ${method.toUpperCase()} resquest`, async () => {
-        const res1 = await agent(strapi.app).get('/posts').expect(200);
+        const res1 = await agent(strapi.app).get('/academies').expect(200);
 
         expect(requests).to.have.lengthOf(1);
 
-        const res2 = await agent(strapi.app)[method]('/posts').expect(200);
+        const res2 = await agent(strapi.app)[method]('/academies').expect(200);
 
         expect(res2.body.uid).to.equal(res1.body.uid + 1);
         expect(requests).to.have.lengthOf(2);
 
-        const res3 = await agent(strapi.app).get('/posts').expect(200);
+        const res3 = await agent(strapi.app).get('/academies').expect(200);
 
         expect(res3.body.uid).to.equal(res2.body.uid + 1);
         expect(requests).to.have.lengthOf(3);
       });
 
       it(`busts the cache on an admin panel ${method.toUpperCase()} resquest`, async () => {
-        const res1 = await agent(strapi.app).get('/posts').expect(200);
+        const res1 = await agent(strapi.app).get('/academies').expect(200);
 
         expect(requests).to.have.lengthOf(1);
 
-        const res2 = await agent(strapi.app)[method]('/content-manager/explorer/application::post.post').expect(200);
+        const res2 = await agent(strapi.app)[method]('/content-manager/explorer/application::academy.academy').expect(200);
 
         expect(res2.body.uid).to.equal(res1.body.uid + 1);
         expect(requests).to.have.lengthOf(2);
 
-        const res3 = await agent(strapi.app).get('/posts').expect(200);
+        const res3 = await agent(strapi.app).get('/academies').expect(200);
 
         expect(res3.body.uid).to.equal(res2.body.uid + 1);
         expect(requests).to.have.lengthOf(3);


### PR DESCRIPTION
Fixes #19 