### PR TITLE
ADD: Support for publishing api

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -134,9 +134,11 @@ const Cache = (strapi) => {
         }
       };
 
-      router.post('/content-manager/explorer/:scope',         bustAdmin);
-      router.put('/content-manager/explorer/:scope/:id*',     bustAdmin);
-      router.delete('/content-manager/explorer/:scope/:id*',  bustAdmin);
+      router.post('/content-manager/explorer/:scope',                 bustAdmin);
+      router.post('/content-manager/explorer/:scope/publish/:id*',    bustAdmin);
+      router.post('/content-manager/explorer/:scope/unpublish/:id*',  bustAdmin);
+      router.put('/content-manager/explorer/:scope/:id*',             bustAdmin);
+      router.delete('/content-manager/explorer/:scope/:id*',          bustAdmin);
 
       strapi.app.use(router.routes());
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-middleware-cache",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Cache strapi requests",
   "main": "./lib",
   "scripts": {

--- a/tests/cache.test.js
+++ b/tests/cache.test.js
@@ -114,6 +114,22 @@ describe('Caching', () => {
         expect(res3.body.uid).to.equal(res2.body.uid + 1);
         expect(requests).to.have.lengthOf(3);
       });
+
+      it(`busts the cache on an admin panel ${method.toUpperCase()} publishing change`, async () => {
+        const res1 = await agent(strapi.app).get('/academies').expect(200);
+
+        expect(requests).to.have.lengthOf(1);
+
+        const res2 = await agent(strapi.app)[method]('/content-manager/explorer/application::academy.academy/publish/1').expect(200);
+
+        expect(res2.body.uid).to.equal(res1.body.uid + 1);
+        expect(requests).to.have.lengthOf(2);
+
+        const res3 = await agent(strapi.app).get('/academies').expect(200);
+
+        expect(res3.body.uid).to.equal(res2.body.uid + 1);
+        expect(requests).to.have.lengthOf(3);
+      });
     });
   });
 


### PR DESCRIPTION
Cache is now busted on calls to the publishing endpoints

e.g

`POST /content-manager/explorer/application::delivery.delivery/publish/1`
`POST /content-manager/explorer/application::delivery.delivery/unpublish/1`

closes #23 