### PR TITLE
ADD: Koa context entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ The module's configuration object supports the following properties
 | maxAge                     | 3600000 | Time in milliseconds after which a cache entry is invalidated                         |
 | cacheTimeout               | 500     | Time in milliseconds after which a cache request is timed out                         |
 | logs                       | true    | Setting it to false will disable any console output                                   |
+| populateContext            | false   | Setting it to true will inject a cache entry point into the Koa context               |
 | redisConfig _(redis only)_ | {}      | The redis config object passed on to [ioredis](https://www.npmjs.com/package/ioredis) |
 
 ### Example
@@ -202,6 +203,38 @@ module.exports = ({ env }) => ({
   }
 });
 ```
+
+## Cache entry point
+
+By setting the `populateContext` configuration to `true`, the middleware will extend the Koa Context with an entry point which can be used to clear the cache from within controllers
+
+```javascript
+// config/middleware.js
+module.exports = ({ env }) => ({
+  settings: {
+    cache: {
+      enabled: true,
+      populateContext: true
+      models: ['post']
+    }
+  }
+});
+
+// controller
+
+module.exports = {
+  async index(ctx) {
+    ctx.middleware.cache.store // A direct access to the cache engine
+    await ctx.middleware.cache.bust({ model: 'posts', id: '123' }); // Will bust the cache for this specific record
+    await ctx.middleware.cache.bust({ model: 'posts' }); // Will bust the cache for the entire model collection
+    await ctx.middleware.cache.bust({ model: 'homepage' }); // For single types, do not pluralize the model name 
+
+    // ...
+  }
+};
+```
+
+**IMPORTANT**: We do not recommend using this unless truly necessary. It is disabled by default as it goes against the non-intrusive/transparent nature of this middleware.
 
 ## Admin panel interactions
 

--- a/lib/defaults.json
+++ b/lib/defaults.json
@@ -5,6 +5,7 @@
     "max": 500,
     "maxAge": 3600000,
     "cacheTimeout": 500,
-    "logs": true
+    "logs": true,
+    "populateContext": false
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,10 @@ const pluralize     = require('pluralize');
 
 const PLUGIN_NAME = 'cache';
 
+const cacheKeyPrefix = ({ model, id = null}) => {
+  return id ? `/${model}/${id}` : `/${model}`;
+}
+
 /**
  * Generates a cache key for the current request
  *
@@ -15,7 +19,7 @@ const generateCacheKey = (model, ctx) => {
   const { params, query = {} } = ctx;
   const { id } = params;
 
-  const prefix = params.id ? `/${model}/${id}` : `/${model}`;
+  const prefix = cacheKeyPrefix({ model, id })
   const suffix = Object
     .keys(query)
     .sort()
@@ -35,6 +39,7 @@ const Cache = (strapi) => {
   const options               = _.get(strapi, `config.middleware.settings.${PLUGIN_NAME}`, {});
   const type                  = _.get(options, 'type', 'mem');
   const allowLogs             = _.get(options, 'logs', true);
+  const withKoaContext        = _.get(options, 'populateContext', false);
   const defaultModelOptions   = { singleType: false };
 
   const info = (msg) => allowLogs && strapi.log.debug(`[Cache] ${msg}`);
@@ -61,6 +66,46 @@ const Cache = (strapi) => {
 
       this.cache = cache;
 
+      // --- Helpers
+
+      /**
+       *
+       * @param {Object} params
+       * @param {string} params.model The model to bust the cache of
+       * @param {string} [params.id] The (optional) ID we want to bust the cache for
+       */
+      const clearCache = async ({ model, id = null }) => {
+        const keys     = await cache.keys() || [];
+        const rexps    = []
+
+        if (!id) {
+          rexps.push(new RegExp(`^/${model}`))        // Bust anything in relation to that model
+        } else {
+          rexps.push(new RegExp(`^/${model}/${id}`))  // Bust the record itself
+          rexps.push(new RegExp(`^/${model}\\?`))     // Bust the collections, but not other individual records
+        }
+
+        const shouldBust = key => _.find(rexps, r => r.test(key))
+        const bust = key => cache.del(key)
+
+        await Promise.all(
+          _.filter(keys, shouldBust).map(bust)
+        );
+      }
+
+
+      // --- Populate Koa Context with cache entry point
+
+      if (withKoaContext) {
+        strapi.app.use((ctx, next) => {
+          _.set(ctx, 'middleware.cache', {
+            bust:   clearCache,
+            store:  cache
+          })
+          return next();
+        });
+      }
+
       // --- Standard REST endpoints
 
       /**
@@ -69,17 +114,14 @@ const Cache = (strapi) => {
        * @param {string} model
        */
       const bust = (model) => async (ctx, next) => {
-        const pattern     = new RegExp(`^/${model}`);
-        const keys        = await cache.keys() || [];
+        const { params } = ctx;
+        const { id } = params;
 
         await next();
 
         if (!_.inRange(ctx.status, 200, 300)) return;
 
-        await Promise.all(
-          _.filter(keys, k => pattern.test(k))
-            .map(k => cache.del(k))
-        );
+        await clearCache({ model, id })
       }
 
       _.each(toCache, (cacheConf) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-middleware-cache",
-  "version": "1.0.11",
+  "version": "1.1.0",
   "description": "Cache strapi requests",
   "main": "./lib",
   "scripts": {


### PR DESCRIPTION
### New option: `populateContext`

By setting the `populateContext` configuration to `true`, the middleware will extend the Koa Context with an entry point which can be used to clear the cache from within controllers

```javascript
// config/middleware.js
module.exports = ({ env }) => ({
  settings: {
    cache: {
      enabled: true,
      populateContext: true
      models: ['post']
    }
  }
});

// controller

module.exports = {
  async index(ctx) {
    ctx.middleware.cache.store // A direct access to the cache engine
    await ctx.middleware.cache.bust({ model: 'posts', id: '123' }); // Will bust the cache for this specific record
    await ctx.middleware.cache.bust({ model: 'posts' }); // Will bust the cache for the entire model collection
    await ctx.middleware.cache.bust({ model: 'homepage' }); // For single types, do not pluralize the model name 

    // ...
  }
};
```

### Optimizations

When clearing the cache for a single record with an ID, the code would previously bust the cache for anything related to that model. It now clears the single record's cache, the collection caches but leaves other single records in the cache

Closes #24 