### PR TITLE
Fix the cache key for complex querystrings

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,7 @@ const generateCacheKey = (model, ctx) => {
   const suffix = Object
     .keys(query)
     .sort()
-    .map(k => `${k}=${query[k]}`)
+    .map(k => `${k}=${JSON.stringify(query[k])}`)
     .join(',');
   const cacheKey = `${prefix}?${suffix}`;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-middleware-cache",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Cache strapi requests",
   "main": "./lib",
   "scripts": {


### PR DESCRIPTION
When the querystring includes params that are actually arrays (i.e. `?_where[0]=...&where[1]=...` (See: https://strapi.io/documentation/v3.x/content-api/parameters.html#complex-queries), the current implementation just calls toString on the value (by way of template literals), which results in `[object Object]` in the cache key and hence breaking the cache.

My fix is using `JSON.stringify` on each querystring param value to avoid this issue, while still keeping the same cache key for different orders of the same querystring (as it was before).

We can also use something like https://github.com/puleos/object-hash to create an md5 hash of the object, but I don't know if it's worth the trouble.