### PR TITLE
fix: Updated admin router endpoints

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -186,11 +186,11 @@ const Cache = (strapi) => {
         }
       };
 
-      router.post('/content-manager/explorer/:scope',                 bustAdmin);
-      router.post('/content-manager/explorer/:scope/publish/:id*',    bustAdmin);
-      router.post('/content-manager/explorer/:scope/unpublish/:id*',  bustAdmin);
-      router.put('/content-manager/explorer/:scope/:id*',             bustAdmin);
-      router.delete('/content-manager/explorer/:scope/:id*',          bustAdmin);
+      router.post('/content-manager/collection-types/:scope',                 bustAdmin);
+      router.post('/content-manager/collection-types/:scope/publish/:id*',    bustAdmin);
+      router.post('/content-manager/collection-types/:scope/unpublish/:id*',  bustAdmin);
+      router.put('/content-manager/collection-types/:scope/:id*',             bustAdmin);
+      router.delete('/content-manager/collection-types/:scope/:id*',          bustAdmin);
 
       strapi.app.use(router.routes());
     },


### PR DESCRIPTION
As discussed in https://github.com/patrixr/strapi-middleware-cache/issues/32 I updated the router endpoints to match the routes Strapi is using in 3.4.0+.