### PR TITLE
Add option to cache by Header values

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ $ strapi develop
 
 ## Per-Model Configuration
 
-Each route can be configured with it's own unique `maxAge`. This can be done simply
+Each route can be configured with it's own unique `maxAge` or to enable caching based on headers. This can be done simply
 by replacing the model strings in the list by object.
 
 e.g
@@ -160,6 +160,10 @@ module.exports = ({ env }) => ({
         {
           model: 'listings',
           maxAge: 1000000,
+        },
+        {
+          model: 'account',
+          headers: ['Authorization']
         }
       ]
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,16 +15,22 @@ const cacheKeyPrefix = ({ model, id = null}) => {
  * @param {object} ctx
  * @returns
  */
-const generateCacheKey = (model, ctx) => {
+const generateCacheKey = (model, ctx, headers) => {
   const { params, query = {} } = ctx;
   const { id } = params;
 
   const prefix = cacheKeyPrefix({ model, id })
-  const suffix = Object
-    .keys(query)
+  const querySuffix = Object.keys(query)
     .sort()
-    .map(k => `${k}=${JSON.stringify(query[k])}`)
-    .join(',');
+    .map((k) => `${k}=${JSON.stringify(query[k])}`)
+    .join(",");
+  const headersSuffix = headers
+    .sort()
+    .filter((k) => ctx.request.header[k.toLowerCase()] !== undefined)
+    .map((k) => `${k}=${JSON.stringify(ctx.request.header[k.toLowerCase()])}`)
+    .join(",");
+
+  const suffix = `${querySuffix}${headersSuffix}`;
   const cacheKey = `${prefix}?${suffix}`;
 
   return { prefix, suffix, cacheKey };
@@ -41,7 +47,7 @@ const Cache = (strapi) => {
   const allowLogs             = _.get(options, 'logs', true);
   const withKoaContext        = _.get(options, 'populateContext', false);
   const withStrapiMiddleware  = _.get(options, 'populateStrapiMiddleware', false);
-  const defaultModelOptions   = { singleType: false };
+  const defaultModelOptions   = { singleType: false, headers: [] };
 
   const info = (msg) => allowLogs && strapi.log.debug(`[Cache] ${msg}`);
 
@@ -135,7 +141,7 @@ const Cache = (strapi) => {
       }
 
       _.each(toCache, (cacheConf) => {
-        const { model, maxAge = options.maxAge } = cacheConf;
+        const { model, maxAge = options.maxAge, headers = options.headers } = cacheConf;
         const endpoint = `/${model}/:id*`;
         
         info(`Caching route ${endpoint} [maxAge=${maxAge}]`);
@@ -144,7 +150,7 @@ const Cache = (strapi) => {
         router.post(endpoint, bust(model));
         router.put(endpoint, bust(model));
         router.get(endpoint, async (ctx, next) => {
-          const { cacheKey } = generateCacheKey(model, ctx);
+          const { cacheKey } = generateCacheKey(model, ctx, headers);
 
           const cacheEntry = await cache.get(cacheKey);
 

--- a/tests/cache.test.js
+++ b/tests/cache.test.js
@@ -24,6 +24,10 @@ describe('Caching', () => {
               {
                 model: 'homepage',
                 singleType: true
+              },
+              {
+                model: 'account',
+                headers: ['Authorization'],
               }
             ]
           }
@@ -78,6 +82,22 @@ describe('Caching', () => {
 
       expect(res1.body.uid).to.equal(res2.body.uid);
       expect(requests).to.have.lengthOf(1);
+    });
+
+    it("caches based on headers ", async () => {
+      const res1 = await agent(strapi.app).get("/accounts/1").expect(200);
+
+      expect(requests).to.have.lengthOf(1);
+
+      const res2 = await agent(strapi.app).get("/accounts/1").expect(200);
+
+      expect(res1.body.uid).to.equal(res2.body.uid);
+      expect(requests).to.have.lengthOf(1);
+
+      const res3 = await agent(strapi.app).get("/accounts/1").set("Authorization", "some_token").expect(200);
+
+      expect(res1.body.uid).not.to.equal(res3.body.uid);
+      expect(requests).to.have.lengthOf(2);
     });
 
     it('doesnt cache models not present in the config', async () => {


### PR DESCRIPTION
This PR adds the ability to enable caching based on header values.
This is most applicable for Authorization as currently authentication will be skipped if the model is already present in the cache.