### PR TITLE
Add ETag support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 const createCache   = require('./cache');
 const Router        = require('koa-router');
+const crypto        = require('crypto');
 const _             = require('lodash');
 const pluralize     = require('pluralize');
 
@@ -42,6 +43,7 @@ const Cache = (strapi) => {
   const withKoaContext        = _.get(options, 'populateContext', false);
   const withStrapiMiddleware  = _.get(options, 'populateStrapiMiddleware', false);
   const bypassServingCache    = _.get(options, 'bypassServingCache', false);
+  const cacheEtag             = _.get(options, 'cacheEtag', false);
   const defaultModelOptions   = { singleType: false };
 
   const info = (msg) => allowLogs && strapi.log.debug(`[Cache] ${msg}`);
@@ -159,6 +161,11 @@ const Cache = (strapi) => {
 
           if (ctx.body && ctx.status == 200) {
             await cache.set(cacheKey, ctx.body, maxAge);
+
+            if (cacheEtag) {
+              const etag = crypto.createHash('md5').update(JSON.stringify(ctx.body)).digest('hex');
+              await cache.set(`${cacheKey}_etag`, `"${etag}"`, maxAge);
+            }
           }
         });
       });

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,8 +42,7 @@ const Cache = (strapi) => {
   const allowLogs             = _.get(options, 'logs', true);
   const withKoaContext        = _.get(options, 'populateContext', false);
   const withStrapiMiddleware  = _.get(options, 'populateStrapiMiddleware', false);
-  const bypassServingCache    = _.get(options, 'bypassServingCache', false);
-  const cacheEtag             = _.get(options, 'cacheEtag', false);
+  const enableEtagSupport     = _.get(options, 'enableEtagSupport', false);
   const defaultModelOptions   = { singleType: false };
 
   const info = (msg) => allowLogs && strapi.log.debug(`[Cache] ${msg}`);
@@ -151,9 +150,22 @@ const Cache = (strapi) => {
 
           const cacheEntry = await cache.get(cacheKey);
 
-          if (cacheEntry && !bypassServingCache) {
-            ctx.status  = 200;
-            ctx.body    = cacheEntry;
+          if (enableEtagSupport) {
+            const ifNoneMatch = ctx.request.headers['if-none-match'];
+            const etagEntry = await cache.get(`${cacheKey}_etag`);
+            const etagMatch = ifNoneMatch === etagEntry;
+
+            if (!etagMatch) {
+              ctx.response.etag = etagEntry;
+            } else {
+              ctx.status =  304;
+              return;
+            }
+          }
+
+          if (cacheEntry) {
+            ctx.status =  200;
+            ctx.body =    cacheEntry;
             return;
           }
 
@@ -162,8 +174,11 @@ const Cache = (strapi) => {
           if (ctx.body && ctx.status == 200) {
             await cache.set(cacheKey, ctx.body, maxAge);
 
-            if (cacheEtag) {
+            if (enableEtagSupport) {
               const etag = crypto.createHash('md5').update(JSON.stringify(ctx.body)).digest('hex');
+
+              ctx.response.etag = etag;
+
               await cache.set(`${cacheKey}_etag`, `"${etag}"`, maxAge);
             }
           }

--- a/lib/index.js
+++ b/lib/index.js
@@ -158,14 +158,14 @@ const Cache = (strapi) => {
             if (!etagMatch) {
               ctx.response.etag = etagEntry;
             } else {
-              ctx.status =  304;
+              ctx.status = 304;
               return;
             }
           }
 
           if (cacheEntry) {
-            ctx.status =  200;
-            ctx.body =    cacheEntry;
+            ctx.status  = 200;
+            ctx.body    = cacheEntry;
             return;
           }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -41,6 +41,7 @@ const Cache = (strapi) => {
   const allowLogs             = _.get(options, 'logs', true);
   const withKoaContext        = _.get(options, 'populateContext', false);
   const withStrapiMiddleware  = _.get(options, 'populateStrapiMiddleware', false);
+  const bypassServingCache    = _.get(options, 'bypassServingCache', false);
   const defaultModelOptions   = { singleType: false };
 
   const info = (msg) => allowLogs && strapi.log.debug(`[Cache] ${msg}`);
@@ -111,7 +112,7 @@ const Cache = (strapi) => {
 
       if (withStrapiMiddleware) {
         _.set(strapi, 'middleware.cache', {
-          bust:   clearCache, 
+          bust:   clearCache,
           store:  cache
         })
       }
@@ -137,7 +138,7 @@ const Cache = (strapi) => {
       _.each(toCache, (cacheConf) => {
         const { model, maxAge = options.maxAge } = cacheConf;
         const endpoint = `/${model}/:id*`;
-        
+
         info(`Caching route ${endpoint} [maxAge=${maxAge}]`);
 
         router.delete(endpoint, bust(model));
@@ -148,7 +149,7 @@ const Cache = (strapi) => {
 
           const cacheEntry = await cache.get(cacheKey);
 
-          if (cacheEntry) {
+          if (cacheEntry && !bypassServingCache) {
             ctx.status  = 200;
             ctx.body    = cacheEntry;
             return;


### PR DESCRIPTION
Hi @patrixr,

So I added basic support for conditional GETs using ETags. I've done some tests and it works as expected on my end.

As proposed, `enableEtagSupport: true` is used in the middleware settings to enable the feature.

I tried to follow the coding style as much as I could, let me know what you think! 