### PR TITLE
Add ETag support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -156,7 +156,7 @@ const Cache = (strapi) => {
             const etagMatch = ifNoneMatch === etagEntry;
 
             if (!etagMatch) {
-              ctx.set('Etag', etagEntry)
+              ctx.set('ETag', etagEntry)
             } else {
               ctx.status = 304;
               return;
@@ -177,7 +177,7 @@ const Cache = (strapi) => {
             if (enableEtagSupport) {
               const etag = crypto.createHash('md5').update(JSON.stringify(ctx.body)).digest('hex');
 
-              ctx.set('Etag', `"${etag}"`)
+              ctx.set('ETag', `"${etag}"`)
 
               await cache.set(`${cacheKey}_etag`, `"${etag}"`, maxAge);
             }

--- a/lib/index.js
+++ b/lib/index.js
@@ -156,7 +156,7 @@ const Cache = (strapi) => {
             const etagMatch = ifNoneMatch === etagEntry;
 
             if (!etagMatch) {
-              ctx.response.etag = etagEntry;
+              ctx.set('Etag', etagEntry)
             } else {
               ctx.status = 304;
               return;
@@ -177,7 +177,7 @@ const Cache = (strapi) => {
             if (enableEtagSupport) {
               const etag = crypto.createHash('md5').update(JSON.stringify(ctx.body)).digest('hex');
 
-              ctx.response.etag = etag;
+              ctx.set('Etag', `"${etag}"`)
 
               await cache.set(`${cacheKey}_etag`, `"${etag}"`, maxAge);
             }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 const createCache   = require('./cache');
 const Router        = require('koa-router');
+const crypto        = require('crypto');
 const _             = require('lodash');
 const pluralize     = require('pluralize');
 
@@ -41,6 +42,7 @@ const Cache = (strapi) => {
   const allowLogs             = _.get(options, 'logs', true);
   const withKoaContext        = _.get(options, 'populateContext', false);
   const withStrapiMiddleware  = _.get(options, 'populateStrapiMiddleware', false);
+  const enableEtagSupport     = _.get(options, 'enableEtagSupport', false);
   const defaultModelOptions   = { singleType: false };
 
   const info = (msg) => allowLogs && strapi.log.debug(`[Cache] ${msg}`);
@@ -111,7 +113,7 @@ const Cache = (strapi) => {
 
       if (withStrapiMiddleware) {
         _.set(strapi, 'middleware.cache', {
-          bust:   clearCache, 
+          bust:   clearCache,
           store:  cache
         })
       }
@@ -137,7 +139,7 @@ const Cache = (strapi) => {
       _.each(toCache, (cacheConf) => {
         const { model, maxAge = options.maxAge } = cacheConf;
         const endpoint = `/${model}/:id*`;
-        
+
         info(`Caching route ${endpoint} [maxAge=${maxAge}]`);
 
         router.delete(endpoint, bust(model));
@@ -147,6 +149,19 @@ const Cache = (strapi) => {
           const { cacheKey } = generateCacheKey(model, ctx);
 
           const cacheEntry = await cache.get(cacheKey);
+
+          if (enableEtagSupport) {
+            const ifNoneMatch = ctx.request.headers['if-none-match'];
+            const etagEntry = await cache.get(`${cacheKey}_etag`);
+            const etagMatch = ifNoneMatch === etagEntry;
+
+            if (!etagMatch) {
+              ctx.response.etag = etagEntry;
+            } else {
+              ctx.status = 304;
+              return;
+            }
+          }
 
           if (cacheEntry) {
             ctx.status  = 200;
@@ -158,6 +173,14 @@ const Cache = (strapi) => {
 
           if (ctx.body && ctx.status == 200) {
             await cache.set(cacheKey, ctx.body, maxAge);
+
+            if (enableEtagSupport) {
+              const etag = crypto.createHash('md5').update(JSON.stringify(ctx.body)).digest('hex');
+
+              ctx.response.etag = etag;
+
+              await cache.set(`${cacheKey}_etag`, `"${etag}"`, maxAge);
+            }
           }
         });
       });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-middleware-cache",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-middleware-cache",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-middleware-cache",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Cache strapi requests",
   "main": "./lib",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-middleware-cache",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Cache strapi requests",
   "main": "./lib",
   "scripts": {


### PR DESCRIPTION
Hi @patrixr,

So I added basic support for conditional GETs using ETags. I've done some tests and it works as expected on my end.

As proposed, `enableEtagSupport: true` is used in the middleware settings to enable the feature.

I tried to follow the coding style as much as I could, let me know what you think!