### PR TITLE
Add relations cache busting

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A cache middleware for the headless CMS strapi.io
 
-![](https://github.com/patrixr/strapi-middleware-cache/workflows/Tests/badge.svg) 
+![](https://github.com/patrixr/strapi-middleware-cache/workflows/Tests/badge.svg)
 ![Maintenance](https://img.shields.io/badge/Maintenance%20-Actively%20Maintained-green.svg)
 
 ## How it works
@@ -217,8 +217,11 @@ module.exports = ({ env }) => ({
 
 By setting the `enableEtagSupport` to `true`, the middleware will automatically create an Etag for each payload it caches.
 
-Further requests sent with the `If-None-Match` header will be returned a `304 Not Modified` status if the content for that url has not changed
+Further requests sent with the `If-None-Match` header will be returned a `304 Not Modified` status if the content for that url has not changed.
 
+## Clearing related cache
+
+By setting the `clearRelatedCache` to `true`, the middleware will inspect the Strapi models before a cache clearing operation to locate models that have relations with the queried model so that their cache is also cleared (this clears the whole cache for the related models). The ispection is performed by looking for direct relations between models and also by doing a deep dive in components, looking for relations to the queried model there too.
 
 ## Cache entry point
 
@@ -245,7 +248,7 @@ module.exports = {
     ctx.middleware.cache.store // A direct access to the cache engine
     await ctx.middleware.cache.bust({ model: 'posts', id: '123' }); // Will bust the cache for this specific record
     await ctx.middleware.cache.bust({ model: 'posts' }); // Will bust the cache for the entire model collection
-    await ctx.middleware.cache.bust({ model: 'homepage' }); // For single types, do not pluralize the model name 
+    await ctx.middleware.cache.bust({ model: 'homepage' }); // For single types, do not pluralize the model name
 
     // ...
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -74,116 +74,126 @@ const Cache = (strapi) => {
 
       /**
        *
+       * @param {string} model The model used to find related caches to bust
+       * @return {array} Array of related models
+       */
+      const getRelatedModels = (model) => {
+        const models = Object.assign(strapi.models, strapi.plugins['users-permissions'].models);
+        const components = strapi.components;
+        const modelKey = _.findKey(models, { 'collectionName': model }) || model;
+        const modelObj = models[modelKey];
+        const attributes = _.get(modelObj, 'allAttributes', {});
+        const relatedComponents = [];
+        const relatedModels = {};
+
+        // first, look for direct relations
+        for (const key in attributes) {
+          const attr = attributes[key];
+
+          if (!attr.via) continue;
+
+          if (attr.collection) {
+            relatedModels[attr.collection] = models[attr.collection];
+          } else if (attr.model && attr.model !== 'file') {
+            relatedModels[attr.model] = models[attr.model];
+          }
+        }
+
+        // second, look for relations to current model in components
+        for (const compKey in components) {
+          const compObj = components[compKey];
+          const attributes = _.get(compObj, 'allAttributes', {});
+
+          // look for the current model
+          for (const key in attributes) {
+            const attr = attributes[key];
+
+            for (const key in attr) {
+              const field = attr[key];
+
+              if (key !== 'model') continue;
+
+              if (field === modelKey) {
+                relatedComponents.push(compKey);
+              }
+            }
+          }
+
+          // look one level deeper
+          for (const key in attributes) {
+            const attr = attributes[key];
+
+            for (const key in attr) {
+              const field = attr[key];
+
+              if (key !== 'component' && key !== 'components') continue;
+
+              if (!relatedModels.hasOwnProperty(modelKey) &&
+                  (relatedComponents.includes(field) ||
+                    (Array.isArray(field) && field.filter(x => relatedComponents.includes(x)).length))) {
+                relatedComponents.push(compKey);
+              }
+            }
+          }
+        }
+
+        // finally locate all the models that have the related components in their models
+        for (const modelKey in models) {
+          const modelObj = models[modelKey];
+          const attributes = _.get(modelObj, 'allAttributes', {});
+
+          for (const key in attributes) {
+            const attr = attributes[key];
+
+            for (const key in attr) {
+              const field = attr[key];
+
+              if (key !== 'component' && key !== 'components') continue;
+
+              if (!relatedModels.hasOwnProperty(modelKey) &&
+                  (relatedComponents.includes(field) ||
+                    (Array.isArray(field) && field.filter(x => relatedComponents.includes(x)).length))) {
+                relatedModels[modelKey] = models[modelKey];
+              }
+            }
+          }
+        }
+
+        return relatedModels;
+      }
+
+      /**
+       *
        * @param {Object} params
        * @param {string} params.model The model to bust the cache of
        * @param {string} [params.id] The (optional) ID we want to bust the cache for
        */
       const clearCache = async ({ model, id = null }) => {
         const keys     = await cache.keys() || [];
-        const rexps    = []
+        const rexps    = [];
 
         if (!id) {
-          rexps.push(new RegExp(`^/${model}`))        // Bust anything in relation to that model
+          rexps.push(new RegExp(`^/${model}`));        // Bust anything in relation to that model
         } else {
-          rexps.push(new RegExp(`^/${model}/${id}`))  // Bust the record itself
-          rexps.push(new RegExp(`^/${model}\\?`))     // Bust the collections, but not other individual records
+          rexps.push(new RegExp(`^/${model}/${id}`));  // Bust the record itself
+          rexps.push(new RegExp(`^/${model}\\?`));     // Bust the collections, but not other individual records
         }
 
         if (clearRelatedCache) {
-          const models = Object.assign(strapi.models, strapi.plugins['users-permissions'].models)
-          const components = strapi.components;
-          const modelKey = _.findKey(models, { 'collectionName': model });
-          const modelObj = models[modelKey];
-          const attributes = _.get(modelObj, 'allAttributes', {});
-          const relatedModels = [];
-          const relatedComponents = [];
-
-          // first, look for direct relations
-          for (const key in attributes) {
-            const attr = attributes[key];
-
-            if (!attr.via) continue;
-
-            if (attr.collection) {
-              relatedModels.push(attr.collection);
-            } else if (attr.model && attr.model !== 'file') {
-              relatedModels.push(attr.model);
-            }
-          }
-
-          // second, look for relations to current model in components
-          for (const compKey in components) {
-            const compObj = components[compKey];
-            const attributes = _.get(compObj, 'allAttributes', {});
-
-            // look for the current model
-            for (const key in attributes) {
-              const attr = attributes[key];
-
-              for (const key in attr) {
-                const field = attr[key];
-
-                if (key !== 'model') continue;
-
-                if (field === modelKey) {
-                  relatedComponents.push(compKey);
-                }
-              }
-            }
-
-            // look one level deeper
-            for (const key in attributes) {
-              const attr = attributes[key];
-
-              for (const key in attr) {
-                const field = attr[key];
-
-                if (key !== 'component' && key !== 'components') continue;
-
-                if (!relatedModels.includes(modelKey) &&
-                    (relatedComponents.includes(field) ||
-                     (Array.isArray(field) && field.filter(x => relatedComponents.includes(x)).length))) {
-                  relatedComponents.push(compKey);
-                }
-              }
-            }
-          }
-
-          // finally locate all the models that have the related components in their models
-          for (const modelKey in models) {
-            const modelObj = models[modelKey];
-            const attributes = _.get(modelObj, 'allAttributes', {});
-
-            for (const key in attributes) {
-              const attr = attributes[key];
-
-              for (const key in attr) {
-                const field = attr[key];
-
-                if (key !== 'component' && key !== 'components') continue;
-
-                if (!relatedModels.includes(modelKey) &&
-                    (relatedComponents.includes(field) ||
-                     (Array.isArray(field) && field.filter(x => relatedComponents.includes(x)).length))) {
-                  relatedModels.push(modelKey);
-                }
-              }
-            }
-          }
+          const relatedModels = getRelatedModels(model);
 
           // prep related models to have their whole cache busted
-          for (const key of relatedModels) {
-            const relatedModel = models[key];
+          _.each(relatedModels, (relatedModel, key) => {
             const relatedModelSlug = relatedModel.kind === 'collectionType'
               ? relatedModel.collectionName
               : key;
 
-            rexps.push(new RegExp(`^/${relatedModelSlug}`))  // Bust all entries from models that have relations with that model
-          }
+            rexps.push(new RegExp(`^/${relatedModelSlug}`));  // Bust all entries from models that have relations with that model
+          });
         }
 
-        const shouldBust = key => _.find(rexps, r => r.test(key))
-        const bust = key => cache.del(key)
+        const shouldBust = key => _.find(rexps, r => r.test(key));
+        const bust = key => cache.del(key);
 
         await Promise.all(
           _.filter(keys, shouldBust).map(bust)

--- a/lib/index.js
+++ b/lib/index.js
@@ -43,6 +43,7 @@ const Cache = (strapi) => {
   const withKoaContext        = _.get(options, 'populateContext', false);
   const withStrapiMiddleware  = _.get(options, 'populateStrapiMiddleware', false);
   const enableEtagSupport     = _.get(options, 'enableEtagSupport', false);
+  const clearRelatedCache     = _.get(options, 'clearRelatedCache', false);
   const defaultModelOptions   = { singleType: false };
 
   const info = (msg) => allowLogs && strapi.log.debug(`[Cache] ${msg}`);
@@ -88,8 +89,49 @@ const Cache = (strapi) => {
           rexps.push(new RegExp(`^/${model}\\?`))     // Bust the collections, but not other individual records
         }
 
+        if (clearRelatedCache) {
+          const models = strapi.models;
+          const components = strapi.components;
+          const modelKey = _.findKey(models, { 'collectionName': model });
+          const modelObj = models[modelKey];
+          const attributes = _.get(modelObj, 'allAttributes', {});
+          const relations = [];
+
+          // first, look for direct relations
+          for (const key in attributes) {
+            const attr = attributes[key];
+
+            if (!attr.via) continue;
+
+            if (attr.collection) {
+              relations.push(attr.collection);
+            } else if (attr.model && attr.model !== 'file') {
+              relations.push(attr.model);
+            }
+          }
+
+          // second, look for relations in components
+          for (const key in components) {
+            const modelObj = components[key];
+            const attributes = _.get(modelObj, 'allAttributes', {});
+
+            console.log(`${key}:`)
+            console.log(attributes)
+          }
+
+          for (const key of relations) {
+            const relatedModel = models[key];
+            const relatedModelSlug = relatedModel.kind === 'collectionType'
+              ? relatedModel.collectionName
+              : key;
+
+            rexps.push(new RegExp(`^/${relatedModelSlug}`))  // Bust all entries from models that have relations with that model
+          }
+        }
+
         const shouldBust = key => _.find(rexps, r => r.test(key))
-        const bust = key => cache.del(key)
+        // const bust = key => cache.del(key)
+        const bust = key => {console.log(key);cache.del(key);}
 
         await Promise.all(
           _.filter(keys, shouldBust).map(bust)
@@ -133,7 +175,7 @@ const Cache = (strapi) => {
 
         if (!_.inRange(ctx.status, 200, 300)) return;
 
-        await clearCache({ model, id })
+        await clearCache({ model, id });
       }
 
       _.each(toCache, (cacheConf) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -90,12 +90,13 @@ const Cache = (strapi) => {
         }
 
         if (clearRelatedCache) {
-          const models = strapi.models;
+          const models = Object.assign(strapi.models, strapi.plugins['users-permissions'].models)
           const components = strapi.components;
           const modelKey = _.findKey(models, { 'collectionName': model });
           const modelObj = models[modelKey];
           const attributes = _.get(modelObj, 'allAttributes', {});
-          const relations = [];
+          const relatedModels = [];
+          const relatedComponents = [];
 
           // first, look for direct relations
           for (const key in attributes) {
@@ -104,22 +105,74 @@ const Cache = (strapi) => {
             if (!attr.via) continue;
 
             if (attr.collection) {
-              relations.push(attr.collection);
+              relatedModels.push(attr.collection);
             } else if (attr.model && attr.model !== 'file') {
-              relations.push(attr.model);
+              relatedModels.push(attr.model);
             }
           }
 
-          // second, look for relations in components
-          for (const key in components) {
-            const modelObj = components[key];
-            const attributes = _.get(modelObj, 'allAttributes', {});
+          // second, look for relations to current model in components
+          for (const compKey in components) {
+            const compObj = components[compKey];
+            const attributes = _.get(compObj, 'allAttributes', {});
 
-            console.log(`${key}:`)
-            console.log(attributes)
+            // look for the current model
+            for (const key in attributes) {
+              const attr = attributes[key];
+
+              for (const key in attr) {
+                const field = attr[key];
+
+                if (key !== 'model') continue;
+
+                if (field === modelKey) {
+                  relatedComponents.push(compKey);
+                }
+              }
+            }
+
+            // look one level deeper
+            for (const key in attributes) {
+              const attr = attributes[key];
+
+              for (const key in attr) {
+                const field = attr[key];
+
+                if (key !== 'component' && key !== 'components') continue;
+
+                if (!relatedModels.includes(modelKey) &&
+                    (relatedComponents.includes(field) ||
+                     (Array.isArray(field) && field.filter(x => relatedComponents.includes(x)).length))) {
+                  relatedComponents.push(compKey);
+                }
+              }
+            }
           }
 
-          for (const key of relations) {
+          // finally locate all the models that have the related components in their models
+          for (const modelKey in models) {
+            const modelObj = models[modelKey];
+            const attributes = _.get(modelObj, 'allAttributes', {});
+
+            for (const key in attributes) {
+              const attr = attributes[key];
+
+              for (const key in attr) {
+                const field = attr[key];
+
+                if (key !== 'component' && key !== 'components') continue;
+
+                if (!relatedModels.includes(modelKey) &&
+                    (relatedComponents.includes(field) ||
+                     (Array.isArray(field) && field.filter(x => relatedComponents.includes(x)).length))) {
+                  relatedModels.push(modelKey);
+                }
+              }
+            }
+          }
+
+          // prep related models to have their whole cache busted
+          for (const key of relatedModels) {
             const relatedModel = models[key];
             const relatedModelSlug = relatedModel.kind === 'collectionType'
               ? relatedModel.collectionName
@@ -130,8 +183,7 @@ const Cache = (strapi) => {
         }
 
         const shouldBust = key => _.find(rexps, r => r.test(key))
-        // const bust = key => cache.del(key)
-        const bust = key => {console.log(key);cache.del(key);}
+        const bust = key => cache.del(key)
 
         await Promise.all(
           _.filter(keys, shouldBust).map(bust)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-middleware-cache",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-middleware-cache",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-middleware-cache",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Cache strapi requests",
   "main": "./lib",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-middleware-cache",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Cache strapi requests",
   "main": "./lib",
   "scripts": {

--- a/tests/stubs/strapi.js
+++ b/tests/stubs/strapi.js
@@ -14,6 +14,68 @@ const strapi = {
     info() {},
     debug() {}
   },
+  models: {
+    academy: {
+      kind: 'collectionType',
+      collectionName: 'academies',
+      allAttributes: {
+        researchers: {
+          via: 'academies',
+          collection: 'researcher',
+        }
+      }
+    },
+    homepage: {
+      kind: 'singleType',
+      allAttributes: {
+        body: {
+          type: 'dynamiczone',
+          components: [
+            'layouts.researchers',
+            'layouts.images',
+          ]
+        }
+      }
+    },
+    researcher: {
+      kind: 'collectionType',
+      collectionName: 'researchers',
+      allAttributes: {
+        academy: {
+          via: 'researcher',
+          collection: 'academy',
+        }
+      }
+    }
+  },
+  plugins: {
+    'users-permissions': {
+      models: {
+        user: {}
+      }
+    }
+  },
+  components: {
+    'fields.researcher': {
+      allAttributes: {
+        researcher: {
+          model: 'researcher'
+        }
+      }
+    },
+    'layouts.researchers': {
+      allAttributes: {
+        text: {
+          type: 'text'
+        },
+        researchers: {
+          type: 'component',
+          repeatable: true,
+          component: 'fields.researcher'
+        }
+      }
+    }
+  },
   start() {
     this.app.use(ctx => {
       const data = {


### PR DESCRIPTION
@patrixr Here's an implementation of an option to bust related caches on POST, PUT and DELETE calls (as per proposed in #13). It piggybacks on the existing `clearCache` helper (that way, if enabled, the related caches will always be busted) and is enabled via a `clearRelatedCache` middleware option.

What it does basically is:

1. Gather the related models by [inspecting the updated model's relations to other models](https://github.com/principalstudio/strapi-middleware-cache/blob/15e756d07d721861178e28a5070b2ba4a8f47667/lib/index.js#L101-L112).
2. It then [goes looking for components that have the updated model as a relation](https://github.com/principalstudio/strapi-middleware-cache/blob/15e756d07d721861178e28a5070b2ba4a8f47667/lib/index.js#L114-L150). We go two levels deep in the components to cover use cases such as a relation in a component that is then included in a dynamic zone.
3. It then [gathers the models where the related components are used](https://github.com/principalstudio/strapi-middleware-cache/blob/15e756d07d721861178e28a5070b2ba4a8f47667/lib/index.js#L152-L172).
4. Finally, [it constructs cache keys for the related models](https://github.com/principalstudio/strapi-middleware-cache/blob/15e756d07d721861178e28a5070b2ba4a8f47667/lib/index.js#L174-L183) and adds them to the existing `rexps` array to be busted alongside the updated model's cache.

It works well, I've tested it in a working Strapi installation. I'm not 100% happy with the structure, there's some repeated code. I've tried to spin off the functionality in a separate helper but it became too convoluted and hard to follow. At least the way it is now it's easy to follow albeit a little clumsy.

Let me know what you think! I can write tests if you agree with the approach, I'd have to add dummy models in the `strapi` instance in the tests, as it lacks the `strapi.models`, `strapi.plugins` and `strapi.components` objects needed to gather the related models.


  