### PR TITLE
New admin endpoints

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@ const Router        = require('koa-router');
 const crypto        = require('crypto');
 const _             = require('lodash');
 const pluralize     = require('pluralize');
+const semver        = require('semver');
 
 const PLUGIN_NAME = 'cache';
 
@@ -319,11 +320,21 @@ const Cache = (strapi) => {
         }
       };
 
-      router.post('/content-manager/explorer/:scope',                 bustAdmin);
-      router.post('/content-manager/explorer/:scope/publish/:id*',    bustAdmin);
-      router.post('/content-manager/explorer/:scope/unpublish/:id*',  bustAdmin);
-      router.put('/content-manager/explorer/:scope/:id*',             bustAdmin);
-      router.delete('/content-manager/explorer/:scope/:id*',          bustAdmin);
+      if (semver.lt(process.version, '3.4.0')) {
+        router.post('/content-manager/explorer/:scope',                 bustAdmin);
+        router.post('/content-manager/explorer/:scope/publish/:id*',    bustAdmin);
+        router.post('/content-manager/explorer/:scope/unpublish/:id*',  bustAdmin);
+        router.put('/content-manager/explorer/:scope/:id*',             bustAdmin);
+        router.delete('/content-manager/explorer/:scope/:id*',          bustAdmin);
+      } else {
+        ['collection-types', 'single-types'].forEach(type => {
+          router.post(`/content-manager/${type}/:scope`,                 bustAdmin);
+          router.post(`/content-manager/${type}/:scope/publish/:id*`,    bustAdmin);
+          router.post(`/content-manager/${type}/:scope/unpublish/:id*`,  bustAdmin);
+          router.put(`/content-manager/${type}/:scope/:id*`,             bustAdmin);
+          router.delete(`/content-manager/${type}/:scope/:id*`,          bustAdmin);
+        });
+      }
 
       strapi.app.use(router.routes());
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-middleware-cache",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,41 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@sinonjs/commons": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.2.tgz",
+      "integrity": "sha512-sruwd86RJHdsVf/AtBoijDmUqJp3B6hF/DGC23C+JaegnDHaZyewCjoVGTdg3J0uz3Zs7NnIT05OBOmML72lQw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.3.1.tgz",
+      "integrity": "sha512-1Hc0b1TtyfBu8ixF/tpfSHTVWKwCBLY4QJbkgnE7HcwyvT2xArDxb4K7dMgqRm3szI+LJbzmW/s4xxEhv6hwDg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -753,6 +788,12 @@
         "esprima": "^4.0.0"
       }
     },
+    "just-extend": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz",
+      "integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==",
+      "dev": true
+    },
     "keygrip": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
@@ -874,6 +915,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
     },
     "log-symbols": {
       "version": "3.0.0",
@@ -1008,6 +1055,19 @@
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
       "dev": true
     },
+    "nise": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.4.tgz",
+      "integrity": "sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
     "node-environment-flags": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
@@ -1016,6 +1076,14 @@
       "requires": {
         "object.getownpropertydescriptors": "^2.0.3",
         "semver": "^5.7.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "normalize-path": {
@@ -1235,10 +1303,27 @@
       "dev": true
     },
     "semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+      "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -1250,6 +1335,43 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+    },
+    "sinon": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.4.tgz",
+      "integrity": "sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.1",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/samsam": "^5.3.1",
+        "diff": "^4.0.2",
+        "nise": "^4.0.4",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "sprintf-js": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-middleware-cache",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Cache strapi requests",
   "main": "./lib",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -28,12 +28,14 @@
     "lodash": "^4.17.15",
     "lru-cache": "^5.1.1",
     "pluralize": "^8.0.0",
-    "redis-lru": "^0.6.0"
+    "redis-lru": "^0.6.0",
+    "semver": "^7.3.4"
   },
   "devDependencies": {
     "chai": "^4.2.0",
     "koa": "^2.11.0",
     "mocha": "^7.1.1",
+    "sinon": "^9.2.4",
     "supertest": "^4.0.2",
     "supertest-koa-agent": "^0.3.2"
   }

--- a/tests/cache.test.js
+++ b/tests/cache.test.js
@@ -2,6 +2,7 @@ const initMiddleware  = require('../lib/index');
 const { expect }      = require('chai');
 const agent           = require('supertest-koa-agent');
 const crypto          = require('crypto');
+const sinon           = require('sinon');
 const {
   strapi,
   requests,
@@ -12,6 +13,7 @@ describe('Caching', () => {
   let middleware = null;
 
   before(() => {
+    sinon.stub(process, 'version').value('3.4.0');
     strapi.config = {
       middleware: {
         settings: {
@@ -55,6 +57,8 @@ describe('Caching', () => {
 
     strapi.start();
   });
+
+  after(() => sinon.restore());
 
   beforeEach(async () => {
     await middleware.cache.reset();
@@ -218,7 +222,7 @@ describe('Caching', () => {
 
         expect(requests).to.have.lengthOf(1);
 
-        const res2 = await agent(strapi.app)[method]('/content-manager/explorer/application::academy.academy').expect(200);
+        const res2 = await agent(strapi.app)[method]('/content-manager/collection-types/application::academy.academy').expect(200);
 
         expect(res2.body.uid).to.equal(res1.body.uid + 1);
         expect(requests).to.have.lengthOf(2);
@@ -234,7 +238,7 @@ describe('Caching', () => {
 
         expect(requests).to.have.lengthOf(1);
 
-        const res2 = await agent(strapi.app)[method]('/content-manager/explorer/application::academy.academy/publish/1').expect(200);
+        const res2 = await agent(strapi.app)[method]('/content-manager/collection-types/application::academy.academy/publish/1').expect(200);
 
         expect(res2.body.uid).to.equal(res1.body.uid + 1);
         expect(requests).to.have.lengthOf(2);
@@ -299,7 +303,7 @@ describe('Caching', () => {
 
         expect(requests).to.have.lengthOf(1);
 
-        const res2 = await agent(strapi.app)[method]('/content-manager/explorer/application::homepage.homepage').expect(200);
+        const res2 = await agent(strapi.app)[method]('/content-manager/single-types/application::homepage.homepage').expect(200);
 
         expect(res2.body.uid).to.equal(res1.body.uid + 1);
         expect(requests).to.have.lengthOf(2);


### PR DESCRIPTION
Fixes #32 

Changes: When the strapi version is `>= 3.4.0`, listen on the new admin endpoints for busting the cache

This is based on #33 by @roelbeerens 

cc @derrickmehaffy 