### PR TITLE
fix: process.version is not reflecting Strapi version

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -321,7 +321,7 @@ const Cache = (strapi) => {
         }
       };
 
-      if (semver.lt(process.version, '3.4.0')) {
+      if (semver.lt(strapi.config.info.strapi, '3.4.0')) {
         // strapi < 3.4.0
         // @see https://github.com/strapi/strapi/blob/v3.3.4/packages/strapi-plugin-content-manager/config/routes.json
         router.post('/content-manager/explorer/:model', bustAdmin);


### PR DESCRIPTION
`process.version` contains NodeJS version instead of installed Strapi one, therefore `bustAdmin` does not work properly for versions older than 3.4.0