### PR TITLE
Fix for issue https://github.com/patrixr/strapi-middleware-cache/issues/75

### DIFF
--- a/lib/utils/generateCacheKey.js
+++ b/lib/utils/generateCacheKey.js
@@ -13,7 +13,7 @@
 function generateCacheKey(cacheConf, ctx) {
   const querySuffix = Object.keys(ctx.query)
     .sort()
-    .map((k) => `${k}=${ctx.query[k]}`) // query strings are key sensitive
+    .map((k) => `${k}=${JSON.stringify(ctx.query[k])}`) // query strings are key sensitive
     .join(',');
   const headersSuffix = cacheConf.headers
     .sort()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-middleware-cache",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "Cache strapi requests",
   "main": "./lib",
   "types": "./types",


### PR DESCRIPTION
This PR fixes the issue by JSON-stringifying the query parameters. Not necessary to url-encode, as the Redis cache accepts  json as key values.

After this fix, nice cache keys are generated for _where query parameters: `LRU-CACHE!-k-strapi-middleware-cache:/model?_where={\"_or\":[{\"param1\":\"A\"},{\"param2\":\"B\"}]}&`

It also works nicely with string query parameters, in which the parameter gets quoted: `LRU-CACHE!-k-strapi-middleware-cache:/model?param1=\"A\"&`